### PR TITLE
Fix HTTP client version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=5.4.0",
     "yiisoft/yii2": ">=2.0.0",
-    "yiisoft/yii2-httpclient": "dev-master"
+    "yiisoft/yii2-httpclient": "^2.0.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I have problem when install component

```
Problem 1
    - Installation request for understeam/yii2-slack ^0.2.1 -> satisfiable by understeam/yii2-slack[v0.2.1].
    - understeam/yii2-slack v0.2.1 requires yiisoft/yii2-httpclient dev-master -> no matching package found.
```

recomend use stable version HTTP client
